### PR TITLE
Add a Dockerfile with basic instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM amd64/ubuntu:impish
+WORKDIR /rusty-psn
+
+RUN apt-get update && \
+    apt-get install -y curl openssl unzip
+
+RUN curl -sL https://github.com/RainbowCookie32/rusty-psn/releases/latest/download/rusty-psn-cli-linux.zip -o rusty-psn-cli-linux.zip && \
+    unzip rusty-psn-cli-linux.zip && \
+    rm rusty-psn-cli-linux.zip && \
+    chmod +x rusty-psn
+
+ENTRYPOINT [ "/rusty-psn/rusty-psn" ]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ dnf install clang clang-devel clang-tools-extra speech-dispatcher-devel libxkbco
 sudo pacman -S libxcb libxkbcommon
 ```
 
+## Docker
+
+Use the supplied Dockerfile to run the rusty-psn CLI on Linux or macOS.
+Build and run as follows:
+
+```
+docker build . -t rusty-psn
+docker run --rm -v ${PWD}/pkgs:/rusty-psn/pkgs rusty-psn
+```
 ---
 
 ## Screenshots


### PR DESCRIPTION
Thanks for this super handy tool!
Since RPCS3 gains quite some popularity on macOS these days, this allows those users to download PSN updates relatively easy as well.

It uses Ubuntu 21.10 as basis since that's the last version that came with OpenSSL 1.1. So this might also help some people with newer Linux distributions.