### PR TITLE
Update base image from Ubuntu 21.10 (EOL) to 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/ubuntu:impish
+FROM amd64/ubuntu:jammy
 WORKDIR /rusty-psn
 
 RUN apt-get update && \


### PR DESCRIPTION
[Ubuntu 21.10 (Impish Indri) reached End of Life on July 14 2022](https://fridge.ubuntu.com/2022/06/01/ubuntu-21-10-impish-indri-reaches-end-of-life-on-july-14-2022/). As a result, trying to read Impish's security package list fails and the Docker build then fails. Upgrading to Ubuntu 22.04 LTS (Jammy Jellyfish) which has an EOL of April 2032. 

Closes #105