### PR TITLE
Fix info fetching not showing errors

### DIFF
--- a/src/egui/mod.rs
+++ b/src/egui/mod.rs
@@ -178,7 +178,7 @@ impl UpdatesApp {
     fn handle_search_promise(&mut self, toasts: &mut Vec<(String, ToastLevel)>) -> Option<()> {
         let is_ready = {
             let promise = self.v.search_promise.as_ref()?;
-            promise.ready()?.is_ok()
+            promise.ready().is_some()
         };
 
         if is_ready {


### PR DESCRIPTION
I've noticed that on the current master when a serial is provided that does not have any updates or for some reason initial fetch for update information fails, no information about error is being provided no matter how long one waits for a result:
![image](https://github.com/user-attachments/assets/3a3c20aa-6b56-441b-8fe8-cbf456051219)

I've checked out what might be the cause of this issue and seems that the part of code that waited for a promise to be ready by checking if promise is resolving to Some, it instead waited for promise resolving to Some and the result of it be Ok, which in case of errors promise resolved to Some, but the result of it was Err.

After changing that toasts about errors started appearing again:
![image](https://github.com/user-attachments/assets/7e8be193-ac14-41e6-b3cf-03190029b591)
