### PR TITLE
Allow dashes in title id

### DIFF
--- a/src/psn/mod.rs
+++ b/src/psn/mod.rs
@@ -51,7 +51,10 @@ impl UpdateInfo {
     }
 
     pub async fn get_info(title_id: String) -> Result<UpdateInfo, UpdateError> {
-        let title_id = title_id.trim().to_uppercase();
+        let title_id = title_id
+            .trim()
+            .replace("-", "") // strip the dash that some sites put in a title id, eg. BCES-xxxxx
+            .to_uppercase();
         let url = format!("https://a0.ww.np.dl.playstation.net/tpl/np/{0}/{0}-ver.xml", title_id);
         let client = reqwest::ClientBuilder::default()
             // Sony has funky certificates, so this needs to be enabled.


### PR DESCRIPTION
I'd like to suggest a tiny change - some sites and databases put a dash "-" between character and numeric parts of title ids, for example a lot of BLES/BCES/BCUS title ids on redump.org seem to include it. I've caught myself multiple times pasting a title id from redump with a dash and seeing an error that there are no available updates where I'd expect some to appear:
![image](https://github.com/user-attachments/assets/bfa28532-1772-4b4d-97de-3ced6fb954c9)

A naive dash replacement to allow title ids with dashes produces expected results:
![image](https://github.com/user-attachments/assets/bbc6fedc-012f-4404-bc1a-e2133004a8a6)

It seems that the dash is only a matter of preference and stripping it from input title_id shouldn't lead to incorrect title id info being fetched.