### PR TITLE
Add option to disable file logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ quick-xml = "0.36.1"
 log = "0.4.22"
 flexi_logger = "0.28.5"
 
-clap = { version = "4.5.13", optional = true, features = ["derive"] }
+clap = { version = "4.5.13", features = ["derive"] }
 crossterm = { version = "0.28.1", optional = true }
 
 reqwest = { version = "0.12.5", default-features = false, features = ["rustls-tls"] }
@@ -30,5 +30,5 @@ tokio = { version = "1.39.2", default-features = false, features = ["rt", "io-ut
 
 [features]
 default = ["egui"]
-cli = ["clap", "crossterm"]
+cli = ["crossterm"]
 egui = ["rfd", "eframe", "egui-notify", "notify-rust"]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,27 +1,15 @@
 use std::io::Write;
 use std::path::PathBuf;
 
-use clap::Parser;
 use bytesize::ByteSize;
 use poll_promise::Promise;
 use tokio::runtime::Runtime;
 use crossterm::{cursor, terminal};
 
 use crate::psn::*;
+use crate::Args;
 
-#[derive(Debug, Parser)]
-#[clap(author, version, about)]
-struct Args {
-    #[clap(short, long, required = true, help = "The serial(s) you want to search for, in quotes and separated by spaces")]
-    titles: Vec<String>,
-    #[clap(short, long, help = "Downloads all available updates printing only errors, without needing user intervention.")]
-    silent: bool,
-    #[clap(short, long, help = "Target folder to save the downloaded update files to.")]
-    destination_path: Option<PathBuf>
-}
-
-pub fn start_app() {
-    let args = Args::parse();
+pub fn start_app(args: Args) {
     let runtime = Runtime::new().unwrap();
 
     let _guard = runtime.enter();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,10 @@
 // On release builds, this hides the console window that's created on Windows.
 #![cfg_attr(all(not(debug_assertions), feature = "egui"), windows_subsystem = "windows")]
 
+#[cfg(feature = "cli")]
+use std::path::PathBuf;
 use flexi_logger::Logger;
+use clap::Parser;
 
 #[macro_use] extern crate log;
 mod psn;
@@ -11,19 +14,43 @@ mod cli;
 #[cfg(feature = "egui")]
 mod egui;
 
+#[derive(Debug, Parser)]
+#[clap(author, version, about)]
+struct Args {
+    #[cfg(feature = "cli")]
+    #[clap(short, long, required = true, help = "The serial(s) you want to search for, in quotes and separated by spaces")]
+    titles: Vec<String>,
+    #[cfg(feature = "cli")]
+    #[clap(short, long, help = "Downloads all available updates printing only errors, without needing user intervention.")]
+    silent: bool,
+    #[cfg(feature = "cli")]
+    #[clap(short, long, help = "Target folder to save the downloaded update files to.")]
+    destination_path: Option<PathBuf>,
+    #[clap(long, help = "Disables writing the program's log to a .log file. Don't use if you need help.")]
+    no_log_file: bool
+}
+
 fn main() {
-    Logger::try_with_str("info")
-        .expect("Failed to create logger")
-        .log_to_file(flexi_logger::FileSpec::default())
+    let args = Args::parse();
+
+    let mut logger = Logger::try_with_str("info")
+        .expect("Failed to create logger");
+
+    if args.no_log_file {
+        logger = logger.do_not_log();
+    } else {
+        logger = logger.log_to_file(flexi_logger::FileSpec::default());
+    }
+
+    logger
         .duplicate_to_stdout(flexi_logger::Duplicate::Error)
         .start()
-        .expect("Failed to start logger!")
-    ;
+        .expect("Failed to start logger!");
 
     #[cfg(feature = "cli")]
     {
         info!("starting cli app");
-        cli::start_app();
+        cli::start_app(args);
     }
     
     #[cfg(feature = "egui")]


### PR DESCRIPTION
I'd like to suggest a small feature - I've noticed that the program with every process instance creates a new .log file and logs regular and debug output into it. I thought that it would be useful to have an option to disable this logging as to not produce a lot of files from multiple runs when they might not be necessary.

I've added a new flag to arguments `-n, --no-file-log` (not sure about that name though but I don't have a better idea for it...) that lets an user control log files writing behaviour - `true` to disable logging and `false` to keep logging. The default of creating log files stays as is. The option is available in both cli and egui versions, but since cli needs more arguments than egui does, their handled arguments differ:
- for egui version:
![image](https://github.com/user-attachments/assets/494750d3-27d4-402a-90a0-976a0c3a30cb)
- for cli version:
![image](https://github.com/user-attachments/assets/d08ad31f-23ff-4fdc-997b-ddac7e454e70)

As an effect of this change now both cli and egui releases are dependent on `clap`, instead of only cli, as the arguments handling has been generalized in `main.rs`.