### PR TITLE
Fix error information about incorrect title id suggesting there are no updates available

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -45,6 +45,10 @@ pub fn start_app(args: Args) {
                 }
                 Err(e) => {
                     match e {
+                        UpdateError::UnhandledErrorResponse(e) => {
+                            error!("Unexpected error received in response from PSN: {e}");
+                            println!("{id}: PSN returned an unexpected error: {e}.");
+                        }
                         UpdateError::InvalidSerial => {
                             error!("Invalid serial for updates query {id}");
                             println!("{id}: The provided serial didn't give any results, double-check your input.");

--- a/src/egui/mod.rs
+++ b/src/egui/mod.rs
@@ -192,6 +192,9 @@ impl UpdatesApp {
                 }
                 Err(ref e) => {
                     match e {
+                        UpdateError::UnhandledErrorResponse(e) => {
+                            toasts.push((format!("Unexpected error received in a response from PSN ({e})."), ToastLevel::Error));
+                        }
                         UpdateError::InvalidSerial => {
                             toasts.push((String::from("The provided serial didn't give any results, double-check your input."), ToastLevel::Error));
                         }


### PR DESCRIPTION
When experimenting with title id changes I've noticed that when providing incorrect title id, the error presented suggest that there are no updates available instead of informing that the title id itself is incorrect:
![image](https://github.com/user-attachments/assets/201607fb-fad5-41a8-80db-0a5481a786a2)

The fix takes into account a response in form of `<Error><Code>...</Code><Error>` tags which are returned with a text "NoSuchKey" in response when requesting the psn backend with an incorrect title id:
![image](https://github.com/user-attachments/assets/b52cbfbf-aafb-4131-b90b-ce75a07b8384)

Although I couldn't trigger a case with only `<Error>` or only `<Code>` tags without the other, there are `warn!`s added when such thing might occur. In case some other error is returned as error code instead of "NoSuchKey" there's an additional type of toast/information added.