### PR TITLE
Fix egui errors when downloading the same title id again

### DIFF
--- a/src/egui/mod.rs
+++ b/src/egui/mod.rs
@@ -362,16 +362,20 @@ impl UpdatesApp {
             ui.separator();
             
             ui.add_enabled_ui(!self.v.serial_query.is_empty() && self.v.search_promise.is_none(), | ui | {
-                let already_searched = self.v.update_results.iter().any(|e| e.title_id == self.v.serial_query);
+                if !input_submitted && !ui.button("Search for updates").clicked() { return; }
 
-                if (input_submitted || ui.button("Search for updates").clicked()) && !already_searched {
-                    info!("Fetching updates for '{}'", self.v.serial_query);
-
-                    let _guard = self.v.rt.enter();
-                    let promise = Promise::spawn_async(UpdateInfo::get_info(self.v.serial_query.clone()));
-                    
-                    self.v.search_promise = Some(promise);
+                let already_searched = self.v.update_results.iter().any(|e| e.title_id == parse_title_id(&self.v.serial_query));
+                if already_searched { 
+                    self.show_notifications("Provided title id results already shown", ToastLevel::Info);
+                    return;
                 }
+
+                info!("Fetching updates for '{}'", self.v.serial_query);
+
+                let _guard = self.v.rt.enter();
+                let promise = Promise::spawn_async(UpdateInfo::get_info(self.v.serial_query.clone()));
+                
+                self.v.search_promise = Some(promise);
             });
 
             ui.add_enabled_ui(!self.v.update_results.is_empty(), | ui | {

--- a/src/psn/mod.rs
+++ b/src/psn/mod.rs
@@ -52,10 +52,7 @@ impl UpdateInfo {
     }
 
     pub async fn get_info(title_id: String) -> Result<UpdateInfo, UpdateError> {
-        let title_id = title_id
-            .trim()
-            .replace("-", "") // strip the dash that some sites put in a title id, eg. BCES-xxxxx
-            .to_uppercase();
+        let title_id = parse_title_id(&title_id);
         let url = format!("https://a0.ww.np.dl.playstation.net/tpl/np/{0}/{0}-ver.xml", title_id);
         let client = reqwest::ClientBuilder::default()
             // Sony has funky certificates, so this needs to be enabled.
@@ -100,6 +97,13 @@ impl UpdateInfo {
             }
         }
     }
+}
+
+pub fn parse_title_id(title_id: &String) -> String {
+    return title_id
+        .trim()
+        .replace("-", "") // strip the dash that some sites put in a title id, eg. BCES-xxxxx
+        .to_uppercase();
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
After my previous PR https://github.com/RainbowCookie32/rusty-psn/pull/233 I've noticed that downloading information for the same title id with a dash more than once results in egui showing incorrect list with errors:
![image](https://github.com/user-attachments/assets/9f998880-2fcd-4d32-b8cc-eca621af5e14)

I've failed to notice in the previous PR that duplication check uses serial ids from fetched packages, which never use dashes in title id, hence they would never match. I've separated the part of code that removes whitespaces and dashes and used it in both places. Additionally, a new prompt has been added in case a user searches for the duplicate title id to not confuse the user when nothing changes in the list:
![image](https://github.com/user-attachments/assets/e1ba7142-82cc-4dc0-9e55-dbdd73726810)
