### PR TITLE
utils.rs: use target_family instead of target_os

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,10 +10,10 @@ use tokio::io::{AsyncReadExt, AsyncSeekExt, SeekFrom};
 
 use crate::psn::DownloadError;
 
-#[cfg(target_os = "windows")]
+#[cfg(target_family = "windows")]
 const INVALID_CHARS: [char; 9] = ['<', '>', ':', '"', '/', '\\', '|', '?', '*'];
 
-#[cfg(target_os = "linux")]
+#[cfg(target_family = "unix")]
 const INVALID_CHARS: [char; 1] = ['/'];
 
 fn sanitize_title(title: &str) -> String {


### PR DESCRIPTION
This PR restores compatibility with macOS.

Commit 06229d854136718cdb5d6841ad39d11c49d5bd8f implicitly reduced the buildability to the windows and linux platforms.

This PR is trying to improve build support with the broadest possible platform support, by using `target_family` instead of `target_os`.

This has been tested for the GUI and CLI version on Intel macOS.