### PR TITLE
Multipart PS4 packages merging in egui release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3255,7 +3255,7 @@ dependencies = [
 
 [[package]]
 name = "rusty-psn"
-version = "0.3.8"
+version = "0.5.2"
 dependencies = [
  "bytesize",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-psn"
-version = "0.3.8"
+version = "0.5.2"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/egui/mod.rs
+++ b/src/egui/mod.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use eframe::egui::{self, Button};
+use eframe::egui::{self};
 use egui_notify::{Toast, Toasts, ToastLevel};
 
 use bytesize::ByteSize;
@@ -298,6 +298,7 @@ impl UpdatesApp {
     }
 
     fn handle_merge_promises(&mut self, toasts: &mut Vec<(String, ToastLevel)>) {
+        let mut finished_merge_indexes: Vec<usize> = Vec::new();
         for i in 0..self.v.merge_queue.len() {
             let merge = &mut self.v.merge_queue[i];
             if let Ok(status) = merge.progress_rx.try_recv() {
@@ -333,7 +334,11 @@ impl UpdatesApp {
                 }
             }
 
-            self.v.merge_queue.remove(i);
+            finished_merge_indexes.push(i);
+        }
+
+        for (_,idx) in finished_merge_indexes.iter().enumerate() {
+            self.v.merge_queue.remove(*idx);
         }
     }
 
@@ -541,7 +546,7 @@ impl UpdatesApp {
                 } else {
                     "This PS4 update is not a multipart update"
                 };
-                let merge_btn = ui.add_enabled(is_mergable, Button::new("Merge parts"))
+                let merge_btn = ui.add_enabled(is_mergable, egui::Button::new("Merge parts"))
                     .on_disabled_hover_text(hover_text);
 
                 match self.title_merge_status(update) {

--- a/src/egui/mod.rs
+++ b/src/egui/mod.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use eframe::egui;
+use eframe::egui::{self, Button};
 use egui_notify::{Toast, Toasts, ToastLevel};
 
 use bytesize::ByteSize;
@@ -459,6 +459,23 @@ impl UpdatesApp {
                         }
                     }
                 }
+
+                if platform_variant != utils::PlaformVariant::PS4 { return; }
+
+                let is_multipart = update.packages.len() > 1;
+                let all_pkgs_completed = update.packages.iter().all(|pkg| {
+                    self.v.completed_downloads.iter().find(|(id, pkg_id)| {
+                        title_id == id && *pkg_id == pkg.id()
+                    }).is_some()
+                });
+                let is_mergable = is_multipart && all_pkgs_completed;
+                let hover_text = if is_multipart {
+                    "All parts need to be completed for merge to be available"
+                } else {
+                    "This PS4 update is not a multipart update"
+                };
+                ui.add_enabled(is_mergable, Button::new("Merge parts"))
+                    .on_disabled_hover_text(hover_text);
             })
             .body(| ui | {
                 ui.add_space(5.0);

--- a/src/egui/mod.rs
+++ b/src/egui/mod.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use eframe::egui::{self};
+use eframe::egui;
 use egui_notify::{Toast, Toasts, ToastLevel};
 
 use bytesize::ByteSize;
@@ -334,7 +334,7 @@ impl UpdatesApp {
             }
         }
 
-        for (_,idx) in finished_merge_indexes.iter().enumerate() {
+        for idx in finished_merge_indexes.iter().rev() {
             self.v.merge_queue.remove(*idx);
         }
     }

--- a/src/egui/mod.rs
+++ b/src/egui/mod.rs
@@ -309,32 +309,29 @@ impl UpdatesApp {
                 merge.last_received_status = status;
             }
 
-            let result = match merge.promise.ready() {
-                Some(res) => res,
-                None => continue
-            };
+            if let Some(result) = merge.promise.ready() {
+                match result {
+                    Ok(_) => {
+                        info!("Merge completed for {}", &merge.title_id);
 
-            match result {
-                Ok(_) => {
-                    info!("Merge completed for {}", &merge.title_id);
-
-                    toasts.push((format!("{} merged successfully!", &merge.title_id), ToastLevel::Success));
-                    self.v.completed_merges.push(merge.title_id.clone());
-                }
-                Err(e) => {
-                    self.v.failed_merges.push(merge.title_id.clone());
-
-                    match e {
-                        MergeError::FilepathMismatch(_) | MergeError::PackagesUnmergable(_) | MergeError::FileMergeFailure => {
-                            toasts.push((format!("Failed to merge {}. Check the log for details.", merge.title_id), ToastLevel::Error));
-                        }
+                        toasts.push((format!("{} merged successfully!", &merge.title_id), ToastLevel::Success));
+                        self.v.completed_merges.push(merge.title_id.clone());
                     }
+                    Err(e) => {
+                        self.v.failed_merges.push(merge.title_id.clone());
 
-                    error!("Could not merge files for {}, reason: {:?}", merge.title_id, e);
+                        match e {
+                            MergeError::FilepathMismatch(_) | MergeError::PackagesUnmergable(_) | MergeError::FileMergeFailure => {
+                                toasts.push((format!("Failed to merge {}. Check the log for details.", merge.title_id), ToastLevel::Error));
+                            }
+                        }
+
+                        error!("Could not merge files for {}, reason: {:?}", merge.title_id, e);
+                    }
                 }
-            }
 
-            finished_merge_indexes.push(i);
+                finished_merge_indexes.push(i);
+            }
         }
 
         for (_,idx) in finished_merge_indexes.iter().enumerate() {

--- a/src/psn/mod.rs
+++ b/src/psn/mod.rs
@@ -57,6 +57,15 @@ impl UpdateInfo {
         }
     }
 
+    pub fn title(&self) -> String {
+        if let Some(title) = self.titles.get(0) {
+            title.clone()
+        }
+        else {
+            String::new()
+        }
+    }
+
     pub async fn get_info(title_id: String) -> Result<UpdateInfo, UpdateError> {
         let title_id = parse_title_id(&title_id);
         let platform_variant = match get_platform_variant(&title_id) {

--- a/src/psn/mod.rs
+++ b/src/psn/mod.rs
@@ -1,4 +1,4 @@
-mod utils;
+pub mod utils;
 mod parser;
 mod manifest_parser;
 

--- a/src/psn/mod.rs
+++ b/src/psn/mod.rs
@@ -172,7 +172,7 @@ impl UpdateInfo {
 
     pub async fn merge_parts(&self, tx: Sender<MergeStatus>, download_path: &PathBuf) -> Result<(), MergeError> {
         if !self.packages.iter().all(|pkg| pkg.part_number.is_some()) {
-            return Err(MergeError::PackagesUnmergable(String::from("some packages for the update are not a partial packages")));
+            return Err(MergeError::PackagesUnmergable(String::from("some packages for the update are not a partial package")));
         }
 
         let mut packages_sorted_by_part_number = self.packages.clone();
@@ -198,7 +198,7 @@ impl UpdateInfo {
             merged_path.push(&merged_file_name);
             let mut package_path = package_download_path.clone();
             package_path.push(&file_name);
-            match copy_pkg_file( &package_path, &merged_path, package.offset).await {
+            match copy_pkg_file(&package_path, &merged_path, package.offset).await {
                 Ok(read_length) => {
                     tx.send(MergeStatus::PartProgress(part_number)).await.unwrap();
                     info!("merged {} bytes from {} to {}", read_length, file_name, merged_file_name);


### PR DESCRIPTION
Since PS4 packages are split into parts it might be necessary for them to be merged into a single file depending on where they are used. There are already tools available that merge the part packages into one usable package (for example https://github.com/Tustin/pkg-merge), so I've thought that `rusty-psn` can also have this feautre added so the user doesn't have to switch tools.

![mpv-shot0001](https://github.com/user-attachments/assets/ef9fa5a4-1649-4ba0-9b18-f7baf112e167)

This PR is only a bare minimum necessary to support this feature. As such this PR only adds support for parts merging in egui version of the tool since this PR already got quite big and I have to ponder a bit how to add it to cli release in such a way that it's a good user experience there. Currently merging also only creates a new file on disk - ideally I would like there to be an option to create the merged version in place by merging N-1 parts into the first part and getting rid of already merged parts, so the disk usage is reduced to minimum, but I plan for that to be a future improvement.

In case an user decides to merge files again on already merged parts, the merge process will start from the beginning and will start overwriting already merged package according to pkg offset values - as such it's non-destructive and it's not prohibited since the same bytes will be written at the same offsets. One of the next improvements planned is to use already merged package for a "verifying" phase when "download all" is clicked, so the parts that are already merged will not be downloaded again, just their hashes checked according to offsets on a merged package, and the whole merging again part will be skipped too.

After merging the merged file is in the same path on disk where part packages are, but it's filename is stripped of part parts, so for example for part file `EP9000-CUSA02171_00-0011223344556677-A0117-V0100_0.pkg` the merged filename will be `EP9000-CUSA02171_00-0011223344556677-A0117-V0100.pkg`.

A video presentation of the process:

https://github.com/user-attachments/assets/aa307763-8064-41b7-b386-1566481172ef

I cross-referenced sha256 hashes of output files with merged files using mentioned above `pkg-merge` tool and the examples I checked seemed to be exactly the same.
