### PR TITLE
Fix random Hash Mismatch errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "rusty-psn"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytesize",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-psn"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/psn/mod.rs
+++ b/src/psn/mod.rs
@@ -308,6 +308,12 @@ impl PackageInfo {
                     error!("Failed to write chunk data: {e}");
                     return Err(DownloadError::Tokio(e));
                 }
+
+            }
+
+            if let Err(e) = pkg_file.sync_all().await {
+                error!("Failed to flush all data to file: {e}");
+                return Err(DownloadError::Tokio(e));
             }
 
             if received_data < self.size {


### PR DESCRIPTION
After delivery of https://github.com/RainbowCookie32/rusty-psn/pull/251 I've noticed that when downloading a lot of small packages at once there is quite a high chance of getting a "Hash mismatch" error even though clicking "Download" again and hashing the file second time results in a successful hash calculation suggesting a false negative.
I've noticed that after all `write_all` calls there doesn't seem to be a `flush` which awaits until all chunks are actually on disk. Adding this flush seems to have fixed the issue and hashing no longer has a random chance to start and read file size from metadata before everything's on disk.