### PR TITLE
actions: releases fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
           
   create_release:
     needs: build_matrix
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     if: github.ref == 'refs/heads/master'
     permissions:
       contents: write
@@ -125,7 +125,7 @@ jobs:
         uses: actions/download-artifact@v4.1.9
         with:
           path: ./artifacts
-          patters: rusty-psn*
+          pattern: rusty-psn*
 
       - name: Create release
         uses: softprops/action-gh-release@v2.2.1


### PR DESCRIPTION
fix typo and run the job on macOS, since that's where I know rust-app-version works