### PR TITLE
Fix IO being suspended when minimizing the application window on Linux

### DIFF
--- a/src/egui/mod.rs
+++ b/src/egui/mod.rs
@@ -10,9 +10,8 @@ use notify_rust::Notification;
 use poll_promise::Promise;
 use serde::{Deserialize, Serialize};
 
-use tokio::runtime::Runtime;
+use tokio::runtime::Handle;
 use tokio::sync::mpsc;
-use tokio::task::yield_now;
 
 use crate::psn::*;
 
@@ -71,7 +70,7 @@ impl Default for AppSettings {
 
 // Values that shouldn't be persisted from run to run.
 struct VolatileData {
-    rt: Runtime,
+    rt_handle: Option<Handle>,
     toasts: Toasts,
 
     clipboard: Option<Box<dyn ClipboardProvider>>,
@@ -109,7 +108,7 @@ impl Default for VolatileData {
         };
 
         VolatileData {
-            rt: Runtime::new().unwrap(),
+            rt_handle: None,
             toasts: Toasts::default().reverse(true).with_anchor(egui_notify::Anchor::BottomRight),
 
             clipboard,
@@ -181,7 +180,7 @@ impl eframe::App for UpdatesApp {
 }
 
 impl UpdatesApp {
-    pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
+    pub fn new(cc: &eframe::CreationContext<'_>, rt_handle: Handle) -> Self {
         let mut fonts = egui::FontDefinitions::default();
 
         fonts.font_data.insert(
@@ -211,24 +210,13 @@ impl UpdatesApp {
 
         cc.egui_ctx.set_fonts(fonts);
 
-        let app: Self = if let Some(storage) = cc.storage {
+        let mut app: Self = if let Some(storage) = cc.storage {
             eframe::get_value(storage, eframe::APP_KEY).unwrap_or_default()
         } else {
             Default::default()
         };
 
-        // Execute tokio runtime in its own thread.
-        // Prevents egui blocking the same thread that tokio runtime is running on,
-        // which can lead to network and io tasks being blocked when the application
-        // is minimised or otherwise suspended by egui.
-        let handle = app.v.rt.handle().clone();
-        std::thread::spawn(move || {
-            handle.block_on(async {
-                loop {
-                    yield_now().await;
-                }
-            })
-        });
+        app.v.rt_handle = Some(rt_handle);
 
         return app;
     }
@@ -432,7 +420,7 @@ impl UpdatesApp {
         let download_size = pkg.size;
         let download_path = self.settings.pkg_download_path.clone();
 
-        let _guard = self.v.rt.enter();
+        let _guard = self.v.rt_handle.as_ref().expect("unexpected lack of runtime").enter();
 
         let download_promise = Promise::spawn_async(async move { pkg.start_download(tx, download_path, serial, title).await });
 
@@ -454,7 +442,7 @@ impl UpdatesApp {
         let download_path = self.settings.pkg_download_path.clone();
         let title_id = update_info.title_id.clone();
 
-        let _guard = self.v.rt.enter();
+        let _guard = self.v.rt_handle.as_ref().expect("unexpected lack of runtime").enter();
 
         let merge_promise = Promise::spawn_async(async move { update_info.merge_parts(tx, &download_path).await });
 
@@ -545,7 +533,7 @@ impl UpdatesApp {
 
                 info!("Fetching updates for '{}'", self.v.serial_query);
 
-                let _guard = self.v.rt.enter();
+                let _guard = self.v.rt_handle.as_ref().expect("unexpected lack of runtime").enter();
                 let promise = Promise::spawn_async(UpdateInfo::get_info(self.v.serial_query.clone()));
 
                 self.v.search_promise = Some(promise);


### PR DESCRIPTION
While experimenting with a solution [to this issue](https://github.com/RainbowCookie32/rusty-psn/issues/296) I've encountered an issue that minimizing the application window leads to downloads and file merges being suspended (and eventually to a lost connection and download failure when the connection to psn is left cold long enough). 

At first I thought that the application has to catch up with window repaints but by investigating network traffic or disk activity it turns out that a minimized window stops activity in `tokio` runtime. I've found [this discussion on the problem](https://github.com/emilk/egui/discussions/3562) (one of the solutions includes the current application behavior but seems like it doesn't help with a minimized window on my system) and as a solution I've found [this example](https://github.com/parasyte/egui-tokio-example/blob/main/src/main.rs). I've adapted the example to use `yield_now` to immediately return control to `tokio` runtime instead of a timeout, since the outstanding awaited timeout in a separate thread would result in a panic when the application is being closed due to runtime closing with outstanding tasks - I've noticed no additional CPU utilization after this change but since we are yielding more often instead of waiting on a very long timer I imagine it has to be more expensive?

When the continuous `request_repaint` in `update` is disabled, the blocking of `tokio` IO tasks is even more noticeable since leaving the app window without any interaction is enough to block everything, so this change may partially prepare for https://github.com/RainbowCookie32/rusty-psn/issues/296 solution in which unnecessary repaints should be reduced.

I've tested the application on my system which is a Linux distro with a 6.14.4-1 kernel. Unfortunately I have no way of checking it on Windows or MacOS so I cannot confirm if anything is being changed on those systems. I would recommend checking the behavior there before merging this change.