### PR TITLE
Do not poll & repaint in a looping "update" call

### DIFF
--- a/src/egui/mod.rs
+++ b/src/egui/mod.rs
@@ -174,7 +174,7 @@ impl eframe::App for UpdatesApp {
             self.show_notifications(msg, level);
         }
 
-        ctx.request_repaint();
+        // ctx.request_repaint();
         self.v.toasts.show(ctx);
     }
 }
@@ -534,7 +534,13 @@ impl UpdatesApp {
                 info!("Fetching updates for '{}'", self.v.serial_query);
 
                 let _guard = self.v.rt_handle.as_ref().expect("unexpected lack of runtime").enter();
-                let promise = Promise::spawn_async(UpdateInfo::get_info(self.v.serial_query.clone()));
+                let serial_query = self.v.serial_query.clone();
+                let ctx = ui.ctx().clone();
+                let promise = Promise::spawn_async(async move {
+                    let result = UpdateInfo::get_info(serial_query).await;
+                    ctx.request_repaint();
+                    result
+                });
 
                 self.v.search_promise = Some(promise);
             });


### PR DESCRIPTION
Closes https://github.com/RainbowCookie32/rusty-psn/issues/296

This change removes `request_repaint` in applications' `update` method which recursively triggered a repaint in order to actively poll on promises and receiver channels.

The search for title promise simply calls a repaint request from its' async task. For downloads and merges polling is moved into their respective async tasks and the polling is being done with `select!` on both their receiver channel and the future which is a source of result for the promise. Since the sync runtime is being ran on a separate thread the async task shares memory with egui thread by `Arc` and `Mutex`. It's not the most elegant solution but it's one that I could come up with that requires the least amount of changes to the code, while still retaining the reactivity of updates on download/merge progress. There are some extra additional changes not relevant to the task and the change itself since I ran `cargo fmt && cargo clippy --fix` against the `egui/mod.rs` file.

I've tested the application for all 3 cases (search, download & merge) and some interactions (windows, notifications, list reactivity etc.) and to me it seems that every case that required manual call to `request_repaint` has been covered, however I'm not sure if I covered every possible case. The observed result of the change is that while nothing is happening and the application window is not being interacted with the application is completely idle, without any cpu usage, contrary to the situation before where application always consumed some cpu while reentering `update` method.

I've tested the change on a linux distro, but as usual I recommend checking it on other platforms as well. 