### PR TITLE
Add PSVita game update support

### DIFF
--- a/src/psn/utils.rs
+++ b/src/psn/utils.rs
@@ -7,7 +7,7 @@ use std::{
     path::PathBuf,
 };
 
-use hmac::{Hmac, Mac, digest::Output};
+use hmac::{digest::Output, Hmac, Mac};
 use sha2::Sha256;
 use tokio::{
     fs::OpenOptions,
@@ -73,7 +73,7 @@ pub fn get_update_info_url(title_id: &str, platform_variant: PlaformVariant) -> 
                 "https://gs-sec.ww.np.dl.playstation.net/plo/np/{0}/{1:x}/{0}-ver.xml",
                 title_id, hmac
             ))
-        },
+        }
         PlaformVariant::PSVita => {
             let hmac = get_title_id_hmac(title_id, "E5E278AA1EE34082A088279C83F9BBC806821C52F2AB5D2B4ABD995450355114")?;
             Ok(format!(

--- a/src/psn/utils.rs
+++ b/src/psn/utils.rs
@@ -7,7 +7,7 @@ use std::{
     path::PathBuf,
 };
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, Mac, digest::Output};
 use sha2::Sha256;
 use tokio::{
     fs::OpenOptions,
@@ -20,6 +20,7 @@ type HmacSha256 = Hmac<Sha256>;
 pub enum PlaformVariant {
     PS3,
     PS4,
+    PSVita,
 }
 
 impl fmt::Display for PlaformVariant {
@@ -37,7 +38,27 @@ pub fn get_platform_variant(title_id: &str) -> Option<PlaformVariant> {
         return Some(PlaformVariant::PS4);
     }
 
+    if title_id.starts_with("PCS") {
+        return Some(PlaformVariant::PSVita);
+    }
+
     None
+}
+
+fn get_title_id_hmac(title_id: &str, key: &str) -> Result<Output<Sha256>, UpdateError> {
+    let key = match hex::decode(key) {
+        Ok(key) => key,
+        Err(_) => return Err(UpdateError::InvalidSerial),
+    };
+    let msg = format!("np_{0}", title_id);
+    let mut hasher = match HmacSha256::new_from_slice(&key) {
+        Ok(hasher) => hasher,
+        Err(_) => return Err(UpdateError::InvalidSerial),
+    };
+
+    hasher.update(msg.as_ref());
+    let hash_bytes = hasher.finalize().into_bytes();
+    Ok(hash_bytes)
 }
 
 pub fn get_update_info_url(title_id: &str, platform_variant: PlaformVariant) -> Result<String, UpdateError> {
@@ -47,22 +68,17 @@ pub fn get_update_info_url(title_id: &str, platform_variant: PlaformVariant) -> 
             title_id
         )),
         PlaformVariant::PS4 => {
-            let key = match hex::decode("AD62E37F905E06BC19593142281C112CEC0E7EC3E97EFDCAEFCDBAAFA6378D84") {
-                Ok(key) => key,
-                Err(_) => return Err(UpdateError::InvalidSerial),
-            };
-            let msg = format!("np_{0}", title_id);
-            let mut hasher = match HmacSha256::new_from_slice(&key) {
-                Ok(hasher) => hasher,
-                Err(_) => return Err(UpdateError::InvalidSerial),
-            };
-
-            hasher.update(msg.as_ref());
-            let hash_bytes = hasher.finalize().into_bytes();
-
+            let hmac = get_title_id_hmac(title_id, "AD62E37F905E06BC19593142281C112CEC0E7EC3E97EFDCAEFCDBAAFA6378D84")?;
             Ok(format!(
                 "https://gs-sec.ww.np.dl.playstation.net/plo/np/{0}/{1:x}/{0}-ver.xml",
-                title_id, hash_bytes
+                title_id, hmac
+            ))
+        },
+        PlaformVariant::PSVita => {
+            let hmac = get_title_id_hmac(title_id, "E5E278AA1EE34082A088279C83F9BBC806821C52F2AB5D2B4ABD995450355114")?;
+            Ok(format!(
+                "https://gs-sec.ww.np.dl.playstation.net/pl/np/{0}/{1:x}/{0}-ver.xml",
+                title_id, hmac
             ))
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -83,7 +83,7 @@ const CHUNK_SIZE: usize = 1024 * 1024 * 128;
 pub async fn hash_file(file: &mut File, hash: &str, hash_whole_file: bool) -> Result<bool, DownloadError> {
     let mut hasher = Sha1::new();
 
-    // Last 0x20 bytes are the SHA1 hash for PS3 updates. PS4 updates don't include hash suffix.
+    // Last 0x20 bytes are the SHA1 hash for PS3 and PS Vita updates. PS4 updates don't include hash suffix.
     let suffix_size = if hash_whole_file { 0 } else { 0x20 };
 
     // If the file size is below the length of the embedded sha1-hash suffix,
@@ -131,5 +131,5 @@ pub async fn hash_file(file: &mut File, hash: &str, hash_whole_file: bool) -> Re
         }
     }
 
-    Ok(hasher.digest().to_string() == hash)
+    Ok(hasher.digest().to_string() == hash.to_lowercase())
 }


### PR DESCRIPTION
This PR adds support for downloading PSVita game updates.
Vita updates are handled mostly the same as PS3 updates, except for a few differences:
- An HMAC hash gets inserted into the update info URL like on PS4, but a different key is used
- The SHA-1 hashsums in the XML are uppercase instead of lowercase
- Different title ID prefix of course :)

<img width="700" height="232" alt="image" src="https://github.com/user-attachments/assets/9b9ca67d-fa0b-4714-8caa-23e66d80df5a" />

