### PR TITLE
Outsource title sanitization to a dedicated crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3340,7 +3340,7 @@ checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "rusty-psn"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "bytesize",
  "clap",
@@ -3358,6 +3358,7 @@ dependencies = [
  "quick-xml 0.38.1",
  "reqwest",
  "rfd",
+ "sanitise-file-name",
  "serde",
  "serde_json",
  "sha1_smol",
@@ -3379,6 +3380,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "sanitise-file-name"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d36299972b96b8ae7e8f04ecbf75fb41a27bf3781af00abcf57609774cb911"
 
 [[package]]
 name = "scoped-tls"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ hmac = "0.12.1"
 sha2 = "0.10.9"
 hex = "0.4.3"
 serde_json = "1.0.142"
+sanitise-file-name = "1.0.0"
 
 log = "0.4.27"
 flexi_logger = "0.31.2"

--- a/src/psn/mod.rs
+++ b/src/psn/mod.rs
@@ -128,17 +128,19 @@ impl UpdateInfo {
                 let titles = &info.titles;
                 info.titles = titles.iter().map(|title| title.replace("\n", " ")).collect();
             }
-            Err(e) => return match e {
-                parser::ParseError::ErrorCode(reason) => {
-                    if reason == "NoSuchKey" {
-                        return Err(UpdateError::InvalidSerial);
-                    }
+            Err(e) => {
+                return match e {
+                    parser::ParseError::ErrorCode(reason) => {
+                        if reason == "NoSuchKey" {
+                            return Err(UpdateError::InvalidSerial);
+                        }
 
-                    Err(UpdateError::UnhandledErrorResponse(reason))
+                        Err(UpdateError::UnhandledErrorResponse(reason))
+                    }
+                    parser::ParseError::XmlParsing(reason) => Err(UpdateError::XmlParsing(reason)),
+                    parser::ParseError::XmlEncodingError(reason) => Err(UpdateError::XmlEncodingError(reason)),
                 }
-                parser::ParseError::XmlParsing(reason) => Err(UpdateError::XmlParsing(reason)),
-                parser::ParseError::XmlEncodingError(reason) => Err(UpdateError::XmlEncodingError(reason)),
-            },
+            }
         }
 
         if platform_variant != PlaformVariant::PS4 {

--- a/src/psn/mod.rs
+++ b/src/psn/mod.rs
@@ -115,6 +115,7 @@ impl UpdateInfo {
         }
 
         let mut info = UpdateInfo::empty(platform_variant);
+
         match parser::parse_response(response_txt, &mut info) {
             Ok(()) => {
                 if info.title_id.is_empty() || info.packages.is_empty() {
@@ -127,16 +128,16 @@ impl UpdateInfo {
                 let titles = &info.titles;
                 info.titles = titles.iter().map(|title| title.replace("\n", " ")).collect();
             }
-            Err(e) => match e {
+            Err(e) => return match e {
                 parser::ParseError::ErrorCode(reason) => {
                     if reason == "NoSuchKey" {
                         return Err(UpdateError::InvalidSerial);
                     }
 
-                    return Err(UpdateError::UnhandledErrorResponse(reason));
+                    Err(UpdateError::UnhandledErrorResponse(reason))
                 }
-                parser::ParseError::XmlParsing(reason) => return Err(UpdateError::XmlParsing(reason)),
-                parser::ParseError::XmlEncodingError(reason) => return Err(UpdateError::XmlEncodingError(reason)),
+                parser::ParseError::XmlParsing(reason) => Err(UpdateError::XmlParsing(reason)),
+                parser::ParseError::XmlEncodingError(reason) => Err(UpdateError::XmlEncodingError(reason)),
             },
         }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,8 +17,19 @@ const INVALID_CHARS: [char; 9] = ['<', '>', ':', '"', '/', '\\', '|', '?', '*'];
 const INVALID_CHARS: [char; 1] = ['/'];
 
 fn sanitize_title(title: &str) -> String {
-    //replace invalid characters with underscores or anything we want lol
-    title.replace(|c| INVALID_CHARS.contains(&c), "_")
+    let options = if cfg!(target_family = "windows") {
+        sanitise_file_name::Options::default()
+    } else {
+        // No need to make filenames boring in other platforms just because
+        // Windows can't have some fun.
+        sanitise_file_name::Options {
+            windows_safe: false,
+            ..sanitise_file_name::Options::default()
+        }
+    };
+    
+    let clean_title = sanitise_file_name::sanitise_with_options(title, &options);
+    clean_title
 }
 
 fn create_old_pkg_path<P>(download_path: P, serial: &str) -> PathBuf

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,7 +27,7 @@ fn sanitize_title(title: &str) -> String {
             ..sanitise_file_name::Options::default()
         }
     };
-    
+
     let clean_title = sanitise_file_name::sanitise_with_options(title, &options);
     clean_title
 }


### PR DESCRIPTION
Windows has 5 billion quirks for file names, better to just use a dedicated crate to make sure we don't step on any landmines. Extra validations for other platforms too.

Should fix #346 